### PR TITLE
Apply image size to parent block

### DIFF
--- a/src/asciidoc.css
+++ b/src/asciidoc.css
@@ -1705,6 +1705,11 @@ td.hdlist2 {
   margin: 0.25em 0 1.25em 0.625em;
 }
 
+.imageblock.inlineimage {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .imageblock > .title {
   margin-bottom: 0;
 }

--- a/src/asciidoc.css
+++ b/src/asciidoc.css
@@ -1705,11 +1705,6 @@ td.hdlist2 {
   margin: 0.25em 0 1.25em 0.625em;
 }
 
-.imageblock.inlineimage {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-}
-
 .imageblock > .title {
   margin-bottom: 0;
 }

--- a/src/asciidoc/templates/Image.tsx
+++ b/src/asciidoc/templates/Image.tsx
@@ -30,6 +30,10 @@ const Image = ({ node }: { node: Block }) => {
         node.getRole() ? node.getRole() : ''
       }`}
       {...getLineNumber(node)}
+      style={{
+        maxWidth: node.getAttribute('width'),
+        maxHeight: node.getAttribute('height'),
+      }}
     >
       <div className="content">{img}</div>
       <CaptionedTitle node={node} />


### PR DESCRIPTION
Can pass a width to the imageblock – uses max width so it handles nicely on smaller screens.

Fixes: https://github.com/oxidecomputer/docs/pull/339#issuecomment-2097049682