### PR TITLE
Try not decoding listing content

### DIFF
--- a/src/asciidoc/templates/Listing.tsx
+++ b/src/asciidoc/templates/Listing.tsx
@@ -7,7 +7,6 @@ const Listing = ({ node }: { node: LiteralBlock }) => {
   const { document } = useConverterContext()
 
   const docAttrs = document.attributes || {}
-  const nowrap = node.attributes.nowrap || docAttrs['prewrap'] === undefined
 
   if (node.style === 'source') {
     const lang = node.language
@@ -19,7 +18,7 @@ const Listing = ({ node }: { node: LiteralBlock }) => {
       >
         <Title text={node.title} />
         <div className="content">
-          <pre className={cn('highlight', nowrap ? ' nowrap' : '')}>
+          <pre className={cn('highlight', node.noWrap ? ' nowrap' : '')}>
             {lang ? (
               <code
                 className={lang ? `language-${lang}` : ''}
@@ -45,10 +44,8 @@ const Listing = ({ node }: { node: LiteralBlock }) => {
         <Title text={node.title} />
         <div className="content">
           <pre
-            className={cn('highlight !block', nowrap ? 'nowrap' : '')}
-            dangerouslySetInnerHTML={{
-              __html: node.content || '',
-            }}
+            className={cn('highlight !block', node.noWrap ? 'nowrap' : '')}
+            dangerouslySetInnerHTML={{ __html: node.content || '' }}
           />
         </div>
       </div>

--- a/src/asciidoc/utils/prepareDocument.ts
+++ b/src/asciidoc/utils/prepareDocument.ts
@@ -147,6 +147,8 @@ export interface LiteralBlock extends BaseBlock {
   type: 'listing'
   source: string
   language: string | undefined
+  decodedContent: string
+  noWrap: boolean
 }
 
 export interface SectionBlock extends BaseBlock {
@@ -325,14 +327,13 @@ export const prepareDocument = (document: AdocTypes.Document) => {
     }
 
     if (type === 'listing' || type === 'literal') {
+      const listingBlock = processedBlock as LiteralBlock
       if ('getSource' in block) {
-        const listingBlock = processedBlock as LiteralBlock
         listingBlock.source = block.getSource()
-        listingBlock.language = block.getAttribute('language')
-        listingBlock.content = listingBlock.content
-          ? decode(listingBlock.content)
-          : undefined
       }
+      listingBlock.noWrap = block.isOption('nowrap')
+      listingBlock.language = block.getAttribute('language')
+      listingBlock.decodedContent = decode(listingBlock.content)
     }
 
     if (type === 'section') {

--- a/src/examples/listing.js
+++ b/src/examples/listing.js
@@ -67,6 +67,11 @@ public class ApplicationConfigurationProvider extends HttpConfigurationProvider 
    }
 }
 ----
+
+// html tags
+----
+MPN1:<MFG>:<PN>:<REV>:<SERIAL>
+----
 `
 
 export default listing


### PR DESCRIPTION
Fixes #44 

I need to test with the design system first. The fact that the content gets syntax highlighted by shiki complicates things — shiki returns a HTML string and my brain is melting trying to figure out what needs decoding/encoding at which point.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.1--canary.50.17947860668.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @oxide/react-asciidoc@1.3.1--canary.50.17947860668.0
  # or 
  yarn add @oxide/react-asciidoc@1.3.1--canary.50.17947860668.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
