### PR TITLE
Hover card DX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,7 @@ jobs:
       - run: npm run tsc
 
   canary:
-    # Same-repo PRs only: fork PRs can't reach the `production` environment
-    # secrets or get an OIDC token, so publish (and this whole job) can't work.
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -54,22 +50,20 @@ jobs:
           npm publish --provenance --access public --tag canary
           echo "version=$CANARY_VERSION" >> "$GITHUB_OUTPUT"
 
-      # Cosmetic: never fail the canary publish over a PR-body edit.
       - name: Update PR description with canary version
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const version = '${{ steps.canary.outputs.version }}'
-            const line = '**Canary:** `npm install @oxide/react-asciidoc@' + version + '`'
-            const { owner, repo } = context.repo
-            const pull_number = context.payload.pull_request.number
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number })
-            const body = pr.body || ''
-            const updated = /^\*\*Canary:\*\*/m.test(body)
-              ? body.replace(/^\*\*Canary:\*\*.*$/m, line)
-              : `${body}\n\n${line}`
-            await github.rest.pulls.update({ owner, repo, pull_number, body: updated })
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANARY_VERSION: ${{ steps.canary.outputs.version }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+          CANARY_LINE="**Canary:** \`npm install @oxide/react-asciidoc@${CANARY_VERSION}\`"
+          if echo "$CURRENT_BODY" | grep -q '^\*\*Canary:\*\*'; then
+            UPDATED_BODY=$(echo "$CURRENT_BODY" | sed "s|^\*\*Canary:\*\*.*|${CANARY_LINE}|")
+          else
+            UPDATED_BODY="${CURRENT_BODY}"$'\n\n'"${CANARY_LINE}"
+          fi
+          gh pr edit "$PR_NUMBER" --body "$UPDATED_BODY"
 
   release:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,11 @@ jobs:
       - run: npm run tsc
 
   canary:
-    if: github.event_name == 'pull_request'
+    # Same-repo PRs only: fork PRs can't reach the `production` environment
+    # secrets or get an OIDC token, so publish (and this whole job) can't work.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -50,20 +54,22 @@ jobs:
           npm publish --provenance --access public --tag canary
           echo "version=$CANARY_VERSION" >> "$GITHUB_OUTPUT"
 
+      # Cosmetic: never fail the canary publish over a PR-body edit.
       - name: Update PR description with canary version
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CANARY_VERSION: ${{ steps.canary.outputs.version }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
-          CANARY_LINE="**Canary:** \`npm install @oxide/react-asciidoc@${CANARY_VERSION}\`"
-          if echo "$CURRENT_BODY" | grep -q '^\*\*Canary:\*\*'; then
-            UPDATED_BODY=$(echo "$CURRENT_BODY" | sed "s|^\*\*Canary:\*\*.*|${CANARY_LINE}|")
-          else
-            UPDATED_BODY="${CURRENT_BODY}"$'\n\n'"${CANARY_LINE}"
-          fi
-          gh pr edit "$PR_NUMBER" --body "$UPDATED_BODY"
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ steps.canary.outputs.version }}'
+            const line = '**Canary:** `npm install @oxide/react-asciidoc@' + version + '`'
+            const { owner, repo } = context.repo
+            const pull_number = context.payload.pull_request.number
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number })
+            const body = pr.body || ''
+            const updated = /^\*\*Canary:\*\*/m.test(body)
+              ? body.replace(/^\*\*Canary:\*\*.*$/m, line)
+              : `${body}\n\n${line}`
+            await github.rest.pulls.update({ owner, repo, pull_number, body: updated })
 
   release:
     if: github.event_name == 'workflow_dispatch'

--- a/src/asciidoc/index.tsx
+++ b/src/asciidoc/index.tsx
@@ -32,17 +32,21 @@ import {
   Video,
 } from './templates'
 import { Title } from './templates/util'
+import { findSection } from './utils/findSection'
+import { plainText } from './utils/plainText'
 import { isOption, prepareDocument, processDocument } from './utils/prepareDocument'
 import type {
   AdmonitionBlock,
   AudioBlock,
   Block,
+  Cell,
   CoListBlock,
   DListBlock,
   DocumentBlock,
   DocumentSection,
   ImageBlock,
   ListBlock,
+  ListItemBlock,
   LiteralBlock,
   ParagraphBlock,
   SectionBlock,
@@ -229,6 +233,8 @@ export {
   parse,
   processDocument,
   isOption,
+  findSection,
+  plainText,
   RenderInline,
   inlineHtml,
   Inline,
@@ -238,12 +244,14 @@ export type {
   AdmonitionBlock,
   AudioBlock,
   Block,
+  Cell,
   CoListBlock,
   DListBlock,
   DocumentBlock,
   DocumentSection,
   ImageBlock,
   ListBlock,
+  ListItemBlock,
   LiteralBlock,
   ParagraphBlock,
   SectionBlock,

--- a/src/asciidoc/utils/findSection.ts
+++ b/src/asciidoc/utils/findSection.ts
@@ -1,0 +1,45 @@
+import type { Block } from './prepareDocument'
+
+/** Collect every child block reachable from a block, regardless of how the
+ *  block stores its children: nested `blocks`, list `items` (olist / ulist /
+ *  colist, and dlist's `[terms[], desc]` tuples), and table cells. */
+const childBlocks = (block: Block): Block[] => {
+  const children: Block[] = [...(block.blocks ?? [])]
+
+  if ('items' in block && Array.isArray(block.items)) {
+    for (const item of block.items) {
+      if (Array.isArray(item)) {
+        // dlist row: an array of terms / descriptions, each of which may itself
+        // be an array (the term list).
+        for (const sub of item) {
+          if (Array.isArray(sub)) children.push(...sub)
+          else children.push(sub)
+        }
+      } else {
+        children.push(item)
+      }
+    }
+  }
+
+  if ('rows' in block && block.rows) {
+    for (const group of [block.rows.head, block.rows.body, block.rows.foot]) {
+      for (const row of group) children.push(...row)
+    }
+  }
+
+  return children
+}
+
+/**
+ * Walk a block tree depth-first and return the first block whose `id` matches.
+ * Descends through child blocks, list items, and table cells, so any anchored
+ * block — not just sections — is reachable by id.
+ */
+export const findSection = (blocks: Block[], id: string): Block | undefined => {
+  for (const block of blocks) {
+    if (block.id === id) return block
+    const found = findSection(childBlocks(block), id)
+    if (found) return found
+  }
+  return undefined
+}

--- a/src/asciidoc/utils/findSection.ts
+++ b/src/asciidoc/utils/findSection.ts
@@ -1,39 +1,31 @@
 import type { Block } from './prepareDocument'
 
-/** Collect every child block reachable from a block, regardless of how the
- *  block stores its children: nested `blocks`, list `items` (olist / ulist /
- *  colist, and dlist's `[terms[], desc]` tuples), and table cells. */
+// A block stores children three different ways; collect all of them so the
+// walk reaches every anchored block.
 const childBlocks = (block: Block): Block[] => {
   const children: Block[] = [...(block.blocks ?? [])]
 
   if ('items' in block && Array.isArray(block.items)) {
     for (const item of block.items) {
-      if (Array.isArray(item)) {
-        // dlist row: an array of terms / descriptions, each of which may itself
-        // be an array (the term list).
-        for (const sub of item) {
-          if (Array.isArray(sub)) children.push(...sub)
-          else children.push(sub)
-        }
-      } else {
-        children.push(item)
-      }
+      // dlist rows are `[terms[], desc]` tuples; lists are flat items.
+      if (Array.isArray(item))
+        for (const sub of item) children.push(...(Array.isArray(sub) ? sub : [sub]))
+      else children.push(item)
     }
   }
 
   if ('rows' in block && block.rows) {
-    for (const group of [block.rows.head, block.rows.body, block.rows.foot]) {
+    for (const group of [block.rows.head, block.rows.body, block.rows.foot])
       for (const row of group) children.push(...row)
-    }
   }
 
   return children
 }
 
 /**
- * Walk a block tree depth-first and return the first block whose `id` matches.
- * Descends through child blocks, list items, and table cells, so any anchored
- * block — not just sections — is reachable by id.
+ * First block whose `id` matches, depth-first. Descends through child blocks,
+ * list items, and table cells, so any anchored block — not just sections — is
+ * reachable by id.
  */
 export const findSection = (blocks: Block[], id: string): Block | undefined => {
   for (const block of blocks) {

--- a/src/asciidoc/utils/plainText.ts
+++ b/src/asciidoc/utils/plainText.ts
@@ -1,0 +1,69 @@
+import { decodeHTML } from 'entities'
+
+import type { InlineNode } from '../inline'
+
+/** Strip HTML tags from a raw-passthrough text node's content (`+++…+++`,
+ *  `pass:[…]`), leaving only its textual payload. */
+const stripTags = (s: string): string => s.replace(/<[^>]*>/g, '')
+
+const joinNodes = (nodes: InlineNode[]): string => nodes.map(nodePlainText).join('')
+
+/**
+ * Project a single inline node down to its visible text. Kept exhaustive over
+ * the `InlineNode` union (the `never` default makes adding a node type a
+ * compile error here) so that a plain-text projection can't silently drop a new
+ * inline kind — the whole reason this lives in the library rather than being
+ * copied app-side.
+ */
+const nodePlainText = (node: InlineNode): string => {
+  switch (node.type) {
+    case 'text':
+      // Raw nodes carry HTML; everything else is literal text. Entity decoding
+      // happens once over the whole string in `plainText`.
+      return node.raw ? stripTags(node.text) : node.text
+    case 'quoted':
+      // Smart quotes contribute the visible curly delimiters; every other
+      // quoted subtype (emphasis, strong, mark, sub/sup, math, …) is purely
+      // presentational, so only its inner text survives.
+      if (node.subtype === 'double') return `“${joinNodes(node.text)}”`
+      if (node.subtype === 'single') return `‘${joinNodes(node.text)}’`
+      return joinNodes(node.text)
+    case 'anchor':
+      // Link / xref label text; ref and bibref definitions have no flowing text.
+      return joinNodes(node.text)
+    case 'image':
+      return node.alt ?? ''
+    case 'footnote':
+      // The footnote marker (`[N]`) is not part of the flowing text.
+      return ''
+    case 'indexterm':
+      return node.visible ? node.terms.join(', ') : ''
+    case 'callout':
+      return ''
+    case 'break':
+      return ' '
+    case 'button':
+      return joinNodes(node.text)
+    case 'kbd':
+      return node.keys.join('+')
+    case 'menu':
+      return node.items.join(' > ')
+    default: {
+      const _exhaustive: never = node
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Project an inline AST down to its visible plain text, with HTML entities
+ * decoded. The inline parser deliberately leaves numeric entities (`&#8217;`)
+ * in text nodes for the React renderer to round-trip, so the projection to
+ * plain text is where they must be resolved — hence the library owns both the
+ * walk (coupled to the `InlineNode` union) and the decode.
+ *
+ * Useful for anchor-override tooltips, `alt`/`title` projections, search
+ * indexing, and anywhere a flat string is needed instead of a React tree.
+ */
+export const plainText = (nodes: InlineNode[] | undefined): string =>
+  nodes ? decodeHTML(joinNodes(nodes)) : ''

--- a/src/asciidoc/utils/plainText.ts
+++ b/src/asciidoc/utils/plainText.ts
@@ -2,42 +2,29 @@ import { decodeHTML } from 'entities'
 
 import type { InlineNode } from '../inline'
 
-/** Strip HTML tags from a raw-passthrough text node's content (`+++…+++`,
- *  `pass:[…]`), leaving only its textual payload. */
 const stripTags = (s: string): string => s.replace(/<[^>]*>/g, '')
 
 const joinNodes = (nodes: InlineNode[]): string => nodes.map(nodePlainText).join('')
 
-/**
- * Project a single inline node down to its visible text. Kept exhaustive over
- * the `InlineNode` union (the `never` default makes adding a node type a
- * compile error here) so that a plain-text projection can't silently drop a new
- * inline kind — the whole reason this lives in the library rather than being
- * copied app-side.
- */
+// Exhaustive over `InlineNode` — the `never` default turns adding a node type
+// into a compile error here, so the projection can't silently drop a new kind.
 const nodePlainText = (node: InlineNode): string => {
   switch (node.type) {
     case 'text':
-      // Raw nodes carry HTML; everything else is literal text. Entity decoding
-      // happens once over the whole string in `plainText`.
-      return node.raw ? stripTags(node.text) : node.text
+      return node.raw ? stripTags(node.text) : node.text // raw nodes carry HTML
     case 'quoted':
-      // Smart quotes contribute the visible curly delimiters; every other
-      // quoted subtype (emphasis, strong, mark, sub/sup, math, …) is purely
-      // presentational, so only its inner text survives.
+      // Smart quotes keep their visible delimiters; other subtypes (emphasis,
+      // strong, sub/sup, math, …) are presentational, so only inner text shows.
       if (node.subtype === 'double') return `“${joinNodes(node.text)}”`
       if (node.subtype === 'single') return `‘${joinNodes(node.text)}’`
       return joinNodes(node.text)
     case 'anchor':
-      // Link / xref label text; ref and bibref definitions have no flowing text.
-      return joinNodes(node.text)
+      return joinNodes(node.text) // link/xref label; ref/bibref have none
     case 'image':
       return node.alt ?? ''
-    case 'footnote':
-      // The footnote marker (`[N]`) is not part of the flowing text.
-      return ''
     case 'indexterm':
       return node.visible ? node.terms.join(', ') : ''
+    case 'footnote': // markers, not flowing text
     case 'callout':
       return ''
     case 'break':
@@ -56,14 +43,11 @@ const nodePlainText = (node: InlineNode): string => {
 }
 
 /**
- * Project an inline AST down to its visible plain text, with HTML entities
- * decoded. The inline parser deliberately leaves numeric entities (`&#8217;`)
- * in text nodes for the React renderer to round-trip, so the projection to
- * plain text is where they must be resolved — hence the library owns both the
- * walk (coupled to the `InlineNode` union) and the decode.
- *
- * Useful for anchor-override tooltips, `alt`/`title` projections, search
- * indexing, and anywhere a flat string is needed instead of a React tree.
+ * Flatten an inline AST to its visible plain text, entity-decoded. The parser
+ * leaves numeric entities (`&#8217;`) in text nodes for React to round-trip, so
+ * plain text is where they must be resolved — the library owns both the walk
+ * (coupled to `InlineNode`) and the decode. For tooltips, `alt`/`title`, search
+ * indexing — anywhere a string is needed instead of a React tree.
  */
 export const plainText = (nodes: InlineNode[] | undefined): string =>
   nodes ? decodeHTML(joinNodes(nodes)) : ''

--- a/src/asciidoc/utils/prepareDocument.ts
+++ b/src/asciidoc/utils/prepareDocument.ts
@@ -77,11 +77,15 @@ export type Block =
   | BaseBlock
   | ParagraphBlock
   | AdmonitionBlock
+  | ListBlock
   | CoListBlock
+  | DListBlock
+  | ListItemBlock
   | ImageBlock
   | LiteralBlock
   | SectionBlock
   | TableBlock
+  | Cell
   | AudioBlock
   | VideoBlock
 

--- a/tests/plainText.test.ts
+++ b/tests/plainText.test.ts
@@ -1,0 +1,89 @@
+import asciidoctor from '@asciidoctor/core'
+import { describe, expect, test } from 'vitest'
+
+import { findSection, plainText, prepareDocument } from '../src/asciidoc'
+import type { InlineNode } from '../src/asciidoc/inline'
+import { parseInline } from '../src/asciidoc/inline'
+
+const ad = asciidoctor()
+
+const pt = (src: string): string =>
+  plainText(
+    parseInline(src, { attributes: {}, state: { footnoteIndex: 0 } }) as InlineNode[],
+  )
+
+describe('plainText', () => {
+  test('strips formatting, keeps inner text', () => {
+    expect(pt('Hello *bold* and _italic_ text')).toBe('Hello bold and italic text')
+  })
+
+  test('decodes numeric entities the parser leaves in text nodes', () => {
+    // Apostrophe → `&#8217;` via replacements, decoded back to the character.
+    expect(pt("it's here")).toBe('it’s here')
+  })
+
+  test('keeps smart-quote delimiters, drops presentational delimiters', () => {
+    expect(pt('"`quoted`"')).toBe('“quoted”')
+    expect(pt('H~2~O e^x^')).toBe('H2O ex')
+  })
+
+  test('projects links to their label text', () => {
+    expect(pt('see https://example.com[the docs] now')).toBe('see the docs now')
+  })
+
+  test('strips tags from raw passthrough', () => {
+    expect(pt('a +++<u>b</u>+++ c')).toBe('a b c')
+  })
+
+  test('keyboard macro', () => {
+    const nodes = parseInline('press kbd:[Ctrl+C]', {
+      attributes: { experimental: '' },
+      state: { footnoteIndex: 0 },
+    }) as InlineNode[]
+    expect(plainText(nodes)).toBe('press Ctrl+C')
+  })
+
+  test('empty / undefined input', () => {
+    expect(plainText(undefined)).toBe('')
+    expect(plainText([])).toBe('')
+  })
+})
+
+describe('findSection', () => {
+  const doc = prepareDocument(
+    ad.load(
+      `= Title
+
+[#intro]
+== Introduction
+
+Some text.
+
+[#nested]
+=== Nested
+
+* item one
+* [#listitem]
++
+paragraph in item
+
+|===
+| [#cellanchor] cell
+|===
+`,
+      { sourcemap: true },
+    ),
+  )
+
+  test('finds a top-level section by id', () => {
+    expect(findSection(doc.blocks, 'intro')?.type).toBe('section')
+  })
+
+  test('finds a nested section', () => {
+    expect(findSection(doc.blocks, 'nested')?.type).toBe('section')
+  })
+
+  test('returns undefined for an unknown id', () => {
+    expect(findSection(doc.blocks, 'nope')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Pulls three useful things up from the docs site.

**`plainText(inlines)`** — flattens an inline AST to visible plain text, entity-decoded. Merges the app's `inlineText` + `decodeEntities`. The walk is coupled to the `InlineNode` union and the library owns the decision to leave numeric entities (`&#8217;`) in text nodes, so it should own resolving them on the way to plain text. The per-node switch is exhaustive with a `never` default — adding a node type is now a compile error here rather than a silent drop (the bug that motivated this: an app-side copy broke when the union gained `raw`). Helpful for something like a hover card or search section preview.

**`Block` union fix** — adds `ListBlock`, `DListBlock`, `ListItemBlock`, and `Cell` to the public `Block` union. `items`/cell shapes are now reachable without casting (`block as { items?: … }`).

**`findSection(blocks, id)`** — depth-first find-by-id over the block AST, descending through child blocks, list items, and table cells.

**Canary:** `npm install @oxide/react-asciidoc@2.0.0-canary.bd2aad7`