### PR TITLE
Add subbed source for subbed syntax highlighting

### DIFF
--- a/src/asciidoc/inline/index.ts
+++ b/src/asciidoc/inline/index.ts
@@ -1,4 +1,4 @@
 export { parseInline, subSpecialchars, subCallouts, subCalloutsRaw } from './parser'
 export type { ParseOptions, ParseState } from './parser'
-export { renderInline, renderInlineAsString } from './renderer'
+export { renderInline, renderInlineAsString, renderInlineAsText } from './renderer'
 export * from './types'

--- a/src/asciidoc/inline/renderer.ts
+++ b/src/asciidoc/inline/renderer.ts
@@ -1,3 +1,5 @@
+import { decodeHTML } from 'entities'
+
 import { InlineNode } from './types'
 
 const QUOTE_TAGS: Record<string, [string, string, boolean?]> = {
@@ -240,4 +242,49 @@ function renderNode(node: InlineNode, iconsFont: boolean): string {
 
 export function renderInlineAsString(nodes: InlineNode[], iconsFont = false): string {
   return renderInline(nodes, iconsFont)
+}
+
+/**
+ * Render an inline AST back to PLAIN TEXT — the substituted source with no HTML
+ * markup. This is the verbatim-source counterpart to `renderInlineAsString`: it
+ * resolves text-level subs (notably `attributes`) but emits the bare code a
+ * syntax highlighter should tokenize rather than HTML5 elements.
+ *
+ *  - `text` nodes: emitted as-is, with `specialcharacters` entities decoded back
+ *    to literal `< > &` when `decodeEntities` is set (verbatim blocks include
+ *    `specialcharacters` by default, so normally `true`). `raw` passthrough
+ *    nodes (`pass:[]` / `+++`) are already-final author HTML — emitted verbatim,
+ *    never decoded.
+ *  - `quoted` / `anchor` / `footnote` / `button`: flattened to their inner text.
+ *    A highlighter wants the code, not `<em>` / `<a>`; these only appear when the
+ *    author opted into `+quotes` / `+macros` on the block.
+ *  - `callout`: preserved raw as `<N>` — the highlighter resolves callouts itself.
+ *  - `break`: a newline.
+ *  - `image` / `kbd` / `menu` / `indexterm`: no meaningful verbatim text — skipped.
+ */
+export function renderInlineAsText(nodes: InlineNode[], decodeEntities = true): string {
+  let out = ''
+  for (const node of nodes) {
+    switch (node.type) {
+      case 'text':
+        out += node.raw ? node.text : decodeEntities ? decodeHTML(node.text) : node.text
+        break
+      case 'quoted':
+      case 'anchor':
+      case 'footnote':
+      case 'button':
+        out += renderInlineAsText(node.text, decodeEntities)
+        break
+      case 'callout':
+        out += `<${node.number}>`
+        break
+      case 'break':
+        out += '\n'
+        break
+      // image / kbd / menu / indexterm: no meaningful verbatim text — skip.
+      default:
+        break
+    }
+  }
+  return out
 }

--- a/src/asciidoc/utils/prepareDocument.ts
+++ b/src/asciidoc/utils/prepareDocument.ts
@@ -4,6 +4,7 @@ import {
   type ParseState,
   parseInline,
   renderInlineAsString,
+  renderInlineAsText,
   subCallouts,
   subSpecialchars,
 } from '../inline'
@@ -174,6 +175,13 @@ export interface LiteralBlock extends BaseBlock {
   type: 'listing'
   source: string
   language: string | undefined
+  /** `source` with the block's resolved text-level substitutions applied
+   *  (notably `attributes`), un-escaped and un-highlighted — the plain code a
+   *  syntax highlighter should tokenize. Equals `source` when the block's subs
+   *  make no text-level change. Callout markers are preserved in raw `<N>` form
+   *  (resolve them with `subCalloutsRaw`). Quote/macro subs, if enabled, are
+   *  flattened to their text. */
+  subbedSource: string
 }
 
 export interface SectionBlock extends BaseBlock {
@@ -892,11 +900,11 @@ export const prepareDocument = (document: AdocTypes.Document) => {
     if (type === 'listing' || type === 'literal') {
       if ('getSource' in block) {
         const listingBlock = processedBlock as LiteralBlock
-        listingBlock.source = block.getSource()
+        const source = block.getSource()
+        listingBlock.source = source
         listingBlock.language = block.getAttribute('language')
         const iconsFont = docAttrs['icons'] === 'font'
         const lineComment = block.getAttribute('line-comment') as string | undefined
-        const verbatimSource = sourceFromBlock(block as AdocTypes.AbstractBlock)
         const subs: string[] =
           block.getSubstitutions && typeof block.getSubstitutions === 'function'
             ? (block.getSubstitutions() as string[])
@@ -911,8 +919,15 @@ export const prepareDocument = (document: AdocTypes.Document) => {
           // the normal verbatim ones, render the inline AST to HTML and
           // then apply callouts on top (callout markers survive the inline
           // parser as escaped &lt;N&gt; text which subCallouts recognises).
+          //
+          // Parse the FULL `source` (not the edge-stripped `sourceFromBlock`),
+          // so the SAME AST yields both `content` — blank-edge-trimmed to match
+          // asciidoctor's HTML — and `subbedSource`, which must keep `source`'s
+          // exact line structure. Deriving both from one parse is what keeps
+          // `{counter:}` / `{set:}` firing exactly once (a second pass would
+          // double-count); the blank-edge trim is applied to the HTML only.
           const inlines = resolveXrefs(
-            parseInline(verbatimSource, {
+            parseInline(source, {
               attributes: inlineAttrsFor(block),
               state: inlineState,
               // Honour the block's exact subs list (e.g. `subs=+macros` runs
@@ -926,12 +941,23 @@ export const prepareDocument = (document: AdocTypes.Document) => {
             content = subCallouts(content, iconsFont, lineComment)
           }
           processedBlock.content = stripVerbatimEdges(content)
+          // Plain subbed source from the same AST: callouts stay raw `<N>`
+          // (never run subCallouts), and no blank-line trim — `subbedSource`
+          // tracks `source`'s line structure, not the trimmed HTML's.
+          listingBlock.subbedSource = renderInlineAsText(
+            inlines ?? [],
+            subs.includes('specialcharacters'),
+          )
         } else {
+          const verbatimSource = sourceFromBlock(block as AdocTypes.AbstractBlock)
           let content = subSpecialchars(verbatimSource)
           if (subs.includes('callouts')) {
             content = subCallouts(content, iconsFont, lineComment)
           }
           processedBlock.content = stripVerbatimEdges(content)
+          // No text-level subs: nothing to resolve — `subbedSource` is the raw
+          // source verbatim (already un-escaped, callout markers intact).
+          listingBlock.subbedSource = source
         }
       }
     }

--- a/tests/subbedSource.test.ts
+++ b/tests/subbedSource.test.ts
@@ -1,0 +1,121 @@
+import asciidoctor from '@asciidoctor/core'
+import { describe, expect, test } from 'vitest'
+
+import { prepareDocument } from '../src/asciidoc'
+import type { Block, LiteralBlock } from '../src/asciidoc/utils/prepareDocument'
+
+// `subbedSource` exposes the substituted, un-escaped plain-text source of a
+// verbatim block — `{attr}` refs resolved, callouts left raw — so a downstream
+// highlighter can tokenize the resolved code instead of re-deriving subs from
+// raw `source`. Verify the substitution semantics the package now owns.
+
+const ad = asciidoctor()
+
+const listings = (source: string): LiteralBlock[] => {
+  const doc = prepareDocument(ad.load(source, { standalone: true }))
+  const out: LiteralBlock[] = []
+  const walk = (blocks: Block[]) => {
+    for (const b of blocks) {
+      if (b.type === 'listing' || b.type === 'literal') out.push(b as LiteralBlock)
+      if (b.blocks) walk(b.blocks)
+    }
+  }
+  walk(doc.blocks)
+  return out
+}
+
+const only = (source: string): LiteralBlock => {
+  const found = listings(source)
+  expect(found).toHaveLength(1)
+  return found[0]
+}
+
+describe('subbedSource', () => {
+  test('resolves attribute refs (subs="+attributes") while raw source stays raw', () => {
+    const block = only(`:api-version: 2026032500.0.0
+
+[source,text,subs="+attributes"]
+----
+api-version: {api-version}
+----`)
+    expect(block.source).toBe('api-version: {api-version}')
+    expect(block.subbedSource).toBe('api-version: 2026032500.0.0')
+  })
+
+  test('subs="normal" resolves attributes too (resolved-list gating, not substring)', () => {
+    const block = only(`:api-version: 2026032500.0.0
+
+[source,text,subs="normal"]
+----
+api-version: {api-version}
+----`)
+    expect(block.subbedSource).toBe('api-version: 2026032500.0.0')
+  })
+
+  test('without +attributes, subbedSource equals raw source (braces stay literal)', () => {
+    const block = only(`:api-version: 2026032500.0.0
+
+[source,text]
+----
+api-version: {api-version}
+----`)
+    expect(block.source).toBe('api-version: {api-version}')
+    expect(block.subbedSource).toBe(block.source)
+  })
+
+  test('escaped attribute ref stays literal; real ref resolves', () => {
+    const block = only(`:api-version: 9
+
+[source,text,subs="+attributes"]
+----
+\\{escaped} and {api-version}
+----`)
+    expect(block.subbedSource).toBe('{escaped} and 9')
+  })
+
+  test('{counter:n} increments exactly once per block (single-pass guard)', () => {
+    // The same counter appears in a section heading and two listings. Deriving
+    // subbedSource from the SAME AST as `content` must not re-substitute — a
+    // second pass would double-increment the shared counter. Sequential 1, 2
+    // across the two listings proves each was parsed exactly once.
+    const found = listings(`:n:
+
+== Step {counter:n}
+
+[source,text,subs="+attributes"]
+----
+listing {counter:n}
+----
+
+[source,text,subs="+attributes"]
+----
+next {counter:n}
+----`)
+    expect(found).toHaveLength(2)
+    expect(found[0].subbedSource).toBe('listing 1')
+    expect(found[1].subbedSource).toBe('next 2')
+    // content (HTML) and subbedSource derive from one parse — same counter value.
+    expect(found[0].content).toBe('listing 1')
+    expect(found[1].content).toBe('next 2')
+  })
+
+  test('callout markers survive raw as <N> (subs="+attributes" path)', () => {
+    const block = only(`[source,ruby,subs="+attributes"]
+----
+puts "hi" # <1>
+----
+<1> prints`)
+    expect(block.subbedSource).toBe('puts "hi" # <1>')
+    // The HTML `content` escapes the marker; subbedSource keeps it raw.
+    expect(block.content).toContain('&lt;1&gt;')
+  })
+
+  test('callout markers survive raw as <N> (default subs path)', () => {
+    const block = only(`[source,ruby]
+----
+puts "hi" # <1>
+----
+<1> prints`)
+    expect(block.subbedSource).toBe('puts "hi" # <1>')
+  })
+})


### PR DESCRIPTION
`source` does not get subbed and therefore you do not get subs in a syntax highlighted block. This adds `subbedSource` which can be used by the highlighter instead.

**Canary:** `npm install @oxide/react-asciidoc@2.1.0-canary.792ad4d`