### PR TITLE
Shrink AST by removing redundant data

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,10 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"
+  },
+  "allowScripts": {
+    "esbuild@0.27.7": true,
+    "fsevents@2.3.2": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/src/asciidoc/utils/findSection.ts
+++ b/src/asciidoc/utils/findSection.ts
@@ -14,8 +14,8 @@ const childBlocks = (block: Block): Block[] => {
     }
   }
 
-  if ('rows' in block && block.rows) {
-    for (const group of [block.rows.head, block.rows.body, block.rows.foot])
+  if ('bodyRows' in block) {
+    for (const group of [block.headRows, block.bodyRows, block.footRows])
       for (const row of group) children.push(...row)
   }
 

--- a/src/asciidoc/utils/prepareDocument.ts
+++ b/src/asciidoc/utils/prepareDocument.ts
@@ -198,7 +198,6 @@ export interface TableBlock extends BaseBlock {
   type: 'table'
   caption: string
   columns: Column[]
-  rows: Row
   headRows: Cell[][]
   bodyRows: Cell[][]
   footRows: Cell[][]
@@ -216,12 +215,6 @@ export type Column = {
   style: string | undefined
 }
 
-export type Row = {
-  head: Cell[][]
-  body: Cell[][]
-  foot: Cell[][]
-}
-
 export interface Cell extends BaseBlock {
   type: 'table_cell'
   columnSpan: number | undefined
@@ -237,9 +230,6 @@ export interface Cell extends BaseBlock {
    *  serialized HTML string. Undefined for asciidoc/literal cells, which
    *  don't go through the inline-string path. */
   contentInlines?: InlineNode[][] | undefined
-  source: string
-  lines: string[]
-  column: Column | undefined
   width: string | undefined
   columnPercentageWidth: string | undefined
 }
@@ -1087,7 +1077,6 @@ export const prepareDocument = (document: AdocTypes.Document) => {
       const headRows = processCellArray(adocTable.getHeadRows())
       const bodyRows = processCellArray(adocTable.getBodyRows())
       const footRows = processCellArray(adocTable.getFootRows())
-      tableBlock.rows = { head: headRows, body: bodyRows, foot: footRows }
 
       tableBlock = {
         ...tableBlock,
@@ -1106,8 +1095,6 @@ export const prepareDocument = (document: AdocTypes.Document) => {
 
     if (type === 'table_cell') {
       const adocCell = block as unknown as AdocTypes.Table.Cell
-
-      const col = adocCell.getColumn()
 
       const rawCellText =
         typeof (adocCell as unknown as { text?: string }).text === 'string'
@@ -1194,21 +1181,8 @@ export const prepareDocument = (document: AdocTypes.Document) => {
         textInlines: cellInlines,
         columnSpan: adocCell.getColumnSpan(),
         rowSpan: adocCell.getRowSpan(),
-        source: adocCell.getSource(),
-        lines: adocCell.getLines(),
         width: adocCell.getWidth(),
         columnPercentageWidth: adocCell.getColumnPercentageWidth(),
-        column: col
-          ? {
-              // @ts-ignore
-              attributes: col.getAttributes(),
-              columnNumber: col.getColumnNumber(),
-              width: col.getWidth(),
-              horizontalAlign: col.getHorizontalAlign(),
-              verticalAlign: col.getVerticalAlign(),
-              style: col.getStyle(),
-            }
-          : undefined,
       }
 
       processedBlock = tableCellBlock
@@ -1286,9 +1260,8 @@ export const prepareDocument = (document: AdocTypes.Document) => {
         }
       }
       // Handle table cells
-      if ('rows' in b && b.rows) {
-        const row = b.rows as Row
-        for (const cellGroup of [row.head, row.body, row.foot]) {
+      if ('bodyRows' in b) {
+        for (const cellGroup of [b.headRows, b.bodyRows, b.footRows]) {
           for (const rowCells of cellGroup) {
             for (const cell of rowCells) {
               if (cell.textInlines) {

--- a/tests/STATUS.md
+++ b/tests/STATUS.md
@@ -34,3 +34,34 @@ See [`CONTEXT.md`](./CONTEXT.md) for how to run, compare, and fix.
 Most remaining failures are architectural (placeholder-vs-gsub inline model, source-order
 attribute/counter resolution) or large feature areas (manpage doctype, nested AsciiDoc table
 cells).
+
+## Serialized AST size (`measure-size.ts`)
+
+`prepareDocument` → `JSON.stringify` byte counts. Run `npx vite-node tests/measure-size.ts`
+(measures the fetched RFD corpus if present, plus a deterministic synthetic table-heavy doc
+the harness generates in-memory — the per-cell-duplication pathology, no committed fixture
+needed).
+
+**2026-06-28** — two changes, both verified by **byte-identical rendered HTML** across all
+707 RFDs (render-hash diff empty) with examples at **79 / 79**, confirming nothing reads the
+dropped data:
+
+1. Dropped write-only `cell.column` / `cell.source` / `cell.lines` (no reader in the org;
+   `LiteralBlock.source` kept — rfd-site feeds it to Mermaid).
+2. Dropped the duplicated `rows` field (and the `Row` type) from `TableBlock` — it held the
+   same cells as the flat `headRows`/`bodyRows`/`footRows` under a second key,
+   double-serialized. The renderer reads the flat arrays; the two internal walkers were
+   rewired to them. (docs already stripped `rows` in its own slim pass — this moves that
+   upstream.)
+
+| Measure                | main (v2.1.1) | + cell fields | + drop `rows` |
+| ---------------------- | ------------- | ------------- | ------------- |
+| Corpus (707 RFDs)      | 88.53 MB      | 69.46 MB      | 52.99 MB      |
+| Synthetic tables       | 17.34 MB      | 10.98 MB      | 5.64 MB       |
+| Synthetic ratio to src | 40.6×         | 25.7×         | 13.2×         |
+
+Cumulative: corpus **−40%**, synthetic table-heavy doc **−67%**. (For reference, the docs
+app's real `metrics/timeseries-schemas` page measured 8.75 MB → 3.09 MB, −65% — same
+pathology; the synthetic doc stands in so no 185 KB blob lives in the repo. The full
+2001-doc corpus count wasn't re-run: the `asciidoctor-extracted` shard has no in-repo fetch
+path. Render-hash invariance is the stronger check for these changes.)

--- a/tests/STATUS.md
+++ b/tests/STATUS.md
@@ -38,9 +38,9 @@ cells).
 ## Serialized AST size (`measure-size.ts`)
 
 `prepareDocument` → `JSON.stringify` byte counts. Run `npx vite-node tests/measure-size.ts`
-(measures the fetched RFD corpus if present, plus a deterministic synthetic table-heavy doc
-the harness generates in-memory — the per-cell-duplication pathology, no committed fixture
-needed).
+(measures the in-repo corpus under `tests/corpus` — the RFD and `asciidoctor-extracted`
+shards — plus a deterministic synthetic table-heavy doc the harness generates in-memory: the
+per-cell-duplication pathology, no committed fixture needed).
 
 **2026-06-28** — two changes, both verified by **byte-identical rendered HTML** across all
 707 RFDs (render-hash diff empty) with examples at **79 / 79**, confirming nothing reads the
@@ -54,14 +54,20 @@ dropped data:
    rewired to them. (docs already stripped `rows` in its own slim pass — this moves that
    upstream.)
 
+**2026-06-29** — re-ran the harness over the **full 2001-doc corpus** (694 RFDs + 1307
+`asciidoctor-extracted`; 14.12 MB source). The `asciidoctor-extracted` shard *is* present
+in-repo under `tests/corpus`, so the earlier RFD-only figure is now superseded. The
+intermediate "+ cell fields" column was reconstructed by dropping only the three cell fields
+on `main` (keeping `rows`); the final column is the branch HEAD.
+
 | Measure                | main (v2.1.1) | + cell fields | + drop `rows` |
 | ---------------------- | ------------- | ------------- | ------------- |
-| Corpus (707 RFDs)      | 88.53 MB      | 69.46 MB      | 52.99 MB      |
+| Corpus (2001 docs)     | 90.99 MB      | 71.77 MB      | 55.20 MB      |
+| Corpus ratio to src    | 6.4×          | 5.1×          | 3.9×          |
 | Synthetic tables       | 17.34 MB      | 10.98 MB      | 5.64 MB       |
 | Synthetic ratio to src | 40.6×         | 25.7×         | 13.2×         |
 
-Cumulative: corpus **−40%**, synthetic table-heavy doc **−67%**. (For reference, the docs
-app's real `metrics/timeseries-schemas` page measured 8.75 MB → 3.09 MB, −65% — same
-pathology; the synthetic doc stands in so no 185 KB blob lives in the repo. The full
-2001-doc corpus count wasn't re-run: the `asciidoctor-extracted` shard has no in-repo fetch
-path. Render-hash invariance is the stronger check for these changes.)
+Cumulative: full corpus **−39%** (cell fields −21%, then `rows` −23%), synthetic table-heavy
+doc **−67%**. (For reference, the docs app's real `metrics/timeseries-schemas` page measured
+8.75 MB → 3.09 MB, −65% — same pathology; the synthetic doc stands in so no 185 KB blob
+lives in the repo. Render-hash invariance is the stronger check for these changes.)

--- a/tests/measure-size.ts
+++ b/tests/measure-size.ts
@@ -1,0 +1,167 @@
+// Run with: npx vite-node tests/measure-size.ts
+//
+// Quantifies the serialized-AST size that `prepareDocument` produces. The
+// parity suite (corpus.*.test.tsx / triage.ts) proves *correctness*; this
+// proves *size*. For each corpus doc it does:
+//   loadAsciidoctor -> prepareDocument -> JSON.stringify -> byte count
+// and prints (1) aggregate corpus AST bytes + ratio to source, (2) a
+// deterministic synthetic table-heavy doc (the per-cell-duplication pathology,
+// generated in-memory — no committed fixture), (3) a per-key breakdown of
+// cumulative serialized bytes so dropped fields show as zero.
+//
+// Run on `main` and on the branch and compare the numbers.
+//
+// Options:
+//   --filter <str>   Only measure docs whose name contains <str>
+//   --top <n>        Show the top <n> keys (default 25)
+import asciidoctor from '@asciidoctor/core'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { prepareDocument } from '../src/asciidoc'
+import type { DocumentBlock } from '../src/asciidoc/utils/prepareDocument'
+import { DEFAULT_ATTRS } from './helpers'
+
+const ROOT = dirname(fileURLToPath(import.meta.url))
+const CORPUS_ROOT = join(ROOT, 'corpus')
+
+// Deterministic synthetic table-heavy document. The per-cell duplication that
+// dominated the docs app's serialized AST lives in big tables; this reproduces
+// that pathology in-memory so the extreme-case number is measurable from the
+// repo alone — no committed fixture. (The real-world instance is the docs app's
+// generated `metrics/timeseries-schemas` page; regenerate it there if you want
+// the exact figure.) Defaults ≈ the docs page's ~13k cells.
+const makeTableHeavyDoc = (tables = 200, rows = 12, cols = 5): string => {
+  const parts = ['= Synthetic table-heavy doc', ':showtitle:', '']
+  for (let t = 0; t < tables; t++) {
+    parts.push(
+      `== Schema ${t}`,
+      '',
+      `.Table ${t}`,
+      `[cols="${'1,'.repeat(cols - 1)}1",options="header"]`,
+      '|===',
+    )
+    parts.push(Array.from({ length: cols }, (_, c) => `| Column ${c}`).join(' '))
+    for (let r = 0; r < rows; r++)
+      parts.push(
+        Array.from(
+          { length: cols },
+          (_, c) => `| field_${r}_${c} value with a few words`,
+        ).join(' '),
+      )
+    parts.push('|===', '')
+  }
+  return parts.join('\n')
+}
+
+const ad = asciidoctor()
+
+const args = process.argv.slice(2)
+const filterArg = args.indexOf('--filter')
+const filter = filterArg >= 0 ? args[filterArg + 1] : undefined
+const topArg = args.indexOf('--top')
+const top = topArg >= 0 ? Number(args[topArg + 1]) : 25
+
+type Doc = { name: string; src: string }
+
+const load = (subdir: string): Doc[] => {
+  const dir = join(CORPUS_ROOT, subdir)
+  if (!existsSync(dir)) return []
+  const out: Doc[] = []
+  const walk = (current: string, prefix: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name)
+      if (entry.isDirectory()) walk(full, `${prefix}${entry.name}/`)
+      else if (entry.name.endsWith('.adoc'))
+        out.push({
+          name: `${subdir}/${prefix}${entry.name}`,
+          src: readFileSync(full, 'utf8'),
+        })
+    }
+  }
+  walk(dir, '')
+  return out.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+const prepare = (src: string): DocumentBlock => {
+  const doc = ad.load(src, { attributes: DEFAULT_ATTRS, standalone: true })
+  return prepareDocument(doc) as DocumentBlock
+}
+
+const utf8 = (s: string) => Buffer.byteLength(s, 'utf8')
+
+// Cumulative serialized bytes attributed to each property name: for every
+// object property we add the byte length of its JSON-serialized value (the
+// cost that would vanish if the key were dropped). Keys nested under the same
+// name across the whole tree accumulate together.
+const sizeByKey = (value: unknown, acc: Map<string, number>): void => {
+  if (Array.isArray(value)) {
+    for (const v of value) sizeByKey(v, acc)
+  } else if (value && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) {
+      const js = JSON.stringify(v)
+      if (js === undefined) continue // undefined / function / symbol — dropped by stringify
+      acc.set(k, (acc.get(k) ?? 0) + utf8(js))
+      sizeByKey(v, acc)
+    }
+  }
+}
+
+const fmtBytes = (n: number): string => {
+  if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(2) + ' MB'
+  if (n >= 1024) return (n / 1024).toFixed(1) + ' KB'
+  return n + ' B'
+}
+
+const measure = (docs: Doc[]) => {
+  let srcBytes = 0
+  let astBytes = 0
+  const keyBytes = new Map<string, number>()
+  for (const { src } of docs) {
+    srcBytes += utf8(src)
+    const prepared = prepare(src)
+    const json = JSON.stringify(prepared)
+    astBytes += utf8(json)
+    sizeByKey(prepared, keyBytes)
+  }
+  return { srcBytes, astBytes, keyBytes }
+}
+
+const printKeyTable = (keyBytes: Map<string, number>, n: number) => {
+  const rows = [...keyBytes.entries()].sort((a, b) => b[1] - a[1]).slice(0, n)
+  const w = Math.max(...rows.map(([k]) => k.length), 3)
+  console.log(`  ${'key'.padEnd(w)}  ${'bytes'.padStart(10)}`)
+  for (const [k, b] of rows) {
+    console.log(`  ${k.padEnd(w)}  ${fmtBytes(b).padStart(10)}`)
+  }
+}
+
+// --- corpus aggregate ---
+let docs = [...load('rfds'), ...load('asciidoctor-extracted'), ...load('writers-guide')]
+if (filter) docs = docs.filter((d) => d.name.includes(filter))
+
+if (docs.length) {
+  const { srcBytes, astBytes, keyBytes } = measure(docs)
+  console.log(`\n=== Corpus (${docs.length} docs) ===`)
+  console.log(`source:     ${fmtBytes(srcBytes)}`)
+  console.log(
+    `serialized: ${fmtBytes(astBytes)}  (${(astBytes / srcBytes).toFixed(1)}x source)`,
+  )
+  console.log(`\nTop ${top} keys by cumulative serialized bytes:`)
+  printKeyTable(keyBytes, top)
+} else {
+  console.log('\n(no corpus docs found under tests/corpus — run tests/fetch-corpus.sh)')
+}
+
+// --- synthetic table-heavy doc (the per-cell duplication pathology) ---
+{
+  const src = makeTableHeavyDoc()
+  const { srcBytes, astBytes, keyBytes } = measure([{ name: 'synthetic-tables', src }])
+  console.log(`\n=== Synthetic table-heavy doc (${fmtBytes(srcBytes)} source) ===`)
+  console.log(
+    `serialized: ${fmtBytes(astBytes)}  (${(astBytes / srcBytes).toFixed(1)}x source)`,
+  )
+  console.log(`\nTop ${top} keys by cumulative serialized bytes:`)
+  printKeyTable(keyBytes, top)
+}


### PR DESCRIPTION
Will write better notes later. Was experimenting with this because I was trying to improve performance on the docs site.

### 🤖 summary

Two redundant pieces of the serialized `DocumentBlock`, both residue from the original 2024 table implementation that mirrored the Asciidoctor AST wholesale:

- `cell.column` / `cell.source` / `cell.lines`: never read by the renderer or by any consumer in the oxidecomputer org (audited: rfd-site / docs / oxide-computer / http-stack-docs / design-system). cell.column copied the full Column object onto every cell.
- `TableBlock.rows` (and the Row type): the same cells the renderer reads via the flat `headRows`/`bodyRows`/`footRows`, stored a second time under {head,body,foot} and serialized twice (shared refs in memory, but JSON.stringify doesn't dedupe). The two internal walkers that used rows (footnote collection, findSection) are rewired to the flat arrays. No external reader; docs already strips rows in its own slim pass.

`LiteralBlock.source` is deliberately kept: rfd-site reads it for Mermaid.

Cuts the serialized AST ~40% across the RFD corpus and ~67% on a table-heavy page, with byte-identical rendered HTML (verified by render-hash over 707 RFDs) and examples unchanged at 79/79.

Adds tests/measure-size.ts (size harness; generates a synthetic table-heavy doc in-memory, no committed fixture). Breaking shape change to the exported Cell and TableBlock interfaces (removed fields + the Row type) -> major bump.

**Canary:** `npm install @oxide/react-asciidoc@2.1.1-canary.5dfaa0d`